### PR TITLE
Update apache license identifier in gemspec

### DIFF
--- a/devise-encryptable.gemspec
+++ b/devise-encryptable.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |gem|
   gem.description   = 'Encryption solution for salted-encryptors on Devise'
   gem.summary       = 'Encryption solution for salted-encryptors on Devise'
   gem.homepage      = 'http://github.com/plataformatec/devise-encryptable'
-  gem.license       = 'Apache 2.0'
+  gem.license       = 'Apache-2.0'
 
   gem.files         = Dir['Changelog.md', 'LICENSE', 'README.md', 'lib/**/*']
   gem.test_files    = Dir['test/**/*.rb']


### PR DESCRIPTION
According to https://spdx.org/licenses/, the correct identifier for the Apache 2.0 license is `Apache-2.0` (instead of `Apache 2.0`).