### PR TITLE
Fix frozen string literal warning in Ruby 3.4

### DIFF
--- a/lib/devise/encryptable/encryptors/sha1.rb
+++ b/lib/devise/encryptable/encryptors/sha1.rb
@@ -19,7 +19,7 @@ module Devise
         # Generate a SHA1 digest joining args. Generated token is something like
         #   --arg1--arg2--arg3--argN--
         def self.secure_digest(*tokens)
-          ::Digest::SHA1.hexdigest('--' << tokens.flatten.join('--') << '--')
+          ::Digest::SHA1.hexdigest(+'--' << tokens.flatten.join('--') << '--')
         end
       end
     end

--- a/lib/devise/encryptable/encryptors/sha512.rb
+++ b/lib/devise/encryptable/encryptors/sha512.rb
@@ -19,7 +19,7 @@ module Devise
         # Generate a Sha512 digest joining args. Generated token is something like
         #   --arg1--arg2--arg3--argN--
         def self.secure_digest(*tokens)
-          ::Digest::SHA512.hexdigest('--' << tokens.flatten.join('--') << '--')
+          ::Digest::SHA512.hexdigest(+'--' << tokens.flatten.join('--') << '--')
         end
       end
     end


### PR DESCRIPTION
This PR fixes the following warning in Ruby 3.4 environment:

```
warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
```